### PR TITLE
Hotfix/Altera tipo do retorno do clock in

### DIFF
--- a/src/main/java/com/sqlutions/altave/controller/ClockInController.java
+++ b/src/main/java/com/sqlutions/altave/controller/ClockInController.java
@@ -1,9 +1,6 @@
 package com.sqlutions.altave.controller;
 
-import com.sqlutions.altave.dto.ClockInRequestDTO;
-import com.sqlutions.altave.dto.ClockInResponseDTO;
-import com.sqlutions.altave.dto.ClockInResponseWithTotalDTO;
-import com.sqlutions.altave.dto.ClockInSearchDTO;
+import com.sqlutions.altave.dto.*;
 import com.sqlutions.altave.service.ClockInService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -85,7 +82,7 @@ public class ClockInController {
                 .build();
 
         if (export) {
-            List<ClockInResponseDTO> result = clockInService.exportClockIns(filters);
+            List<ClockInListDTO> result = clockInService.exportClockIns(filters);
             return ResponseEntity.ok(result);
         } else {
             ClockInResponseWithTotalDTO response = clockInService.searchClockIns(filters, page, size);

--- a/src/main/java/com/sqlutions/altave/service/ClockInService.java
+++ b/src/main/java/com/sqlutions/altave/service/ClockInService.java
@@ -11,5 +11,5 @@ public interface ClockInService {
     ClockInResponseWithTotalDTO searchClockIns(ClockInSearchDTO clockInSearchDTO, int page, int size);
     ClockInResponseDTO updateClockIn(Long id, ClockInRequestDTO clockInRequestDTO) throws ParseException;
     ClockInResponseDTO deleteClockIn(Long id);
-    List<ClockInResponseDTO> exportClockIns(ClockInSearchDTO filters);
+    List<ClockInListDTO> exportClockIns(ClockInSearchDTO filters);
 }

--- a/src/main/java/com/sqlutions/altave/service/impl/ClockInServiceImpl.java
+++ b/src/main/java/com/sqlutions/altave/service/impl/ClockInServiceImpl.java
@@ -221,7 +221,7 @@ public class ClockInServiceImpl implements ClockInService {
     }
 
     @Override
-    public List<ClockInResponseDTO> exportClockIns(ClockInSearchDTO filters) {
+    public List<ClockInListDTO> exportClockIns(ClockInSearchDTO filters) {
         List<ClockIn> allClockIns = clockInRepository.findAllByOrderByDateTimeInDesc();
 
         List<ClockIn> filtered = allClockIns.stream()
@@ -267,7 +267,7 @@ public class ClockInServiceImpl implements ClockInService {
                 .toList();
 
         return filtered.stream()
-                .map(this::mapToDTO)
+                .map(this::mapToListDTO)
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Antes o tipo retornado pelo get que retornava todos os registros e o que retornava os registros com paginação estavam retornando formatos diferentes de entidades com quantidade de atributos diferentes.